### PR TITLE
Refactor 3D model backend to return models

### DIFF
--- a/jdaviz/app.py
+++ b/jdaviz/app.py
@@ -175,6 +175,9 @@ class Application(VuetifyTemplate, HubListener):
         # Add callback that updates the layout when the data item array changes
         self.state.add_callback('stack_items', self.vue_relayout)
 
+        # Add a fitted_models dictionary that the helpers (or user) can access
+        self.fitted_models = {}
+
     @property
     def hub(self):
         """

--- a/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
+++ b/jdaviz/configs/default/plugins/model_fitting/fitting_backend.py
@@ -123,9 +123,11 @@ def _fit_3D(initial_model, spectrum):
 
     # Build cube with empty slabs, one per model parameter. These
     # will store only parameter values for now, so a cube suffices.
-    parameters_cube = np.zeros(shape=(len(initial_model.parameters),
-                                      spectrum.flux.shape[0],
-                                      spectrum.flux.shape[1]))
+    #parameters_cube = np.zeros(shape=(len(initial_model.parameters),
+    #                                  spectrum.flux.shape[0],
+    #                                  spectrum.flux.shape[1]))
+
+    fitted_models = []
 
     # Build cube with empty arrays, one per input spaxel. These
     # will store the flux values corresponding to the fitted
@@ -141,9 +143,10 @@ def _fit_3D(initial_model, spectrum):
             fitted_values = results['fitted_values'][i]
 
             # Store fitted model parameters
-            for index, name in enumerate(model.param_names):
-                param = getattr(model, name)
-                parameters_cube[index, x, y] = param.value
+            #for index, name in enumerate(model.param_names):
+            #    param = getattr(model, name)
+            #    parameters_cube[index, x, y] = param.value
+            fitted_models.append({"x": x, "y": y, "model": model})
 
             # Store fitted values
             output_flux_cube[x, y, :] = fitted_values
@@ -172,22 +175,22 @@ def _fit_3D(initial_model, spectrum):
     pool.close()
 
     # Collect units from all parameters
-    param_units = []
-    for name in initial_model.param_names:
-        param = getattr(initial_model, name)
-        param_units.append(param.unit)
+    #param_units = []
+    #for name in initial_model.param_names:
+    #    param = getattr(initial_model, name)
+    #    param_units.append(param.unit)
 
     # Re-format parameters cube to a dict of 2D Quantity arrays.
-    fitted_parameters = _handle_parameter_units(initial_model,
-                                                parameters_cube,
-                                                param_units)
+    #fitted_parameters = _handle_parameter_units(initial_model,
+    #                                            parameters_cube,
+    #                                            param_units)
 
     # Build output 3D spectrum
     funit = spectrum.flux.unit
     output_spectrum = Spectrum1D(spectral_axis=spectrum.spectral_axis,
                                  flux=output_flux_cube * funit)
 
-    return fitted_parameters, output_spectrum
+    return fitted_models, output_spectrum
 
 
 class SpaxelWorker:

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -372,7 +372,7 @@ class ModelFitting(TemplateMixin):
         self.vue_register_spectrum({"spectrum": fitted_spectrum})
         if not hasattr(self.app, "_fitted_1d_models"):
             self.app._fitted_1d_models = {}
-        self.app._fitted_1d_models[self.model_label] = fitted_model
+        self.app.fitted_models[self.model_label] = fitted_model
 
         # Update component model parameters with fitted values
         if type(self._fitted_model) == QuantityModel:
@@ -431,7 +431,9 @@ class ModelFitting(TemplateMixin):
 
         # Save fitted 3D model in a way that the cubeviz
         # helper can access it.
-        self.app._fitted_3d_models = fitted_model
+        for m in fitted_model:
+            temp_label = "{} ({}, {})".format(self.model_label, m["x"], m["y"])
+            self.app.fitted_models[temp_label] = m["model"]
 
         # Transpose the axis order back
         values = np.moveaxis(fitted_spectrum.flux.value, -1, 0)

--- a/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
+++ b/jdaviz/configs/default/plugins/model_fitting/model_fitting.py
@@ -370,8 +370,6 @@ class ModelFitting(TemplateMixin):
         self._fitted_spectrum = fitted_spectrum
 
         self.vue_register_spectrum({"spectrum": fitted_spectrum})
-        if not hasattr(self.app, "_fitted_1d_models"):
-            self.app._fitted_1d_models = {}
         self.app.fitted_models[self.model_label] = fitted_model
 
         # Update component model parameters with fitted values


### PR DESCRIPTION
This changes what the 3D backend returns as `fitted_model` to be consistent with the 1D case, such that they now both populate an app-level `fitted_models` dictionary with astropy model objects keyed on model label. The way I handled the 3D model labels might not be the best strategy - for now I tacked on the (x,y) pixel coordinates of the spaxel fitted. I'll give some more detail on the follow-up to this in https://github.com/spacetelescope/jdaviz/pull/458