### PR TITLE
POC: Load Cherinka s3d cubes (Spectrum1D, crashing)

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -133,8 +133,12 @@ def _parse_jwst_s3d(app, hdulist, data_label):
     unit = u.Unit(hdulist[1].header.get('BUNIT', 'count'))
     flux = hdulist[1].data << unit
     wcs = WCS(hdulist[1].header, hdulist)
-    sliced_wcs = wcs[:, 0, 0]  # Only want wavelengths
-    data = Spectrum1D(flux, wcs=sliced_wcs)
+    data = Spectrum1D(flux, wcs=wcs)
+
+    # NOTE: Tried to only pass in sliced WCS but got error in Glue.
+    # sliced_wcs = wcs[:, 0, 0]  # Only want wavelengths
+    # data = Spectrum1D(flux, wcs=sliced_wcs)
+
     app.add_data(data, data_label)
     app.add_data_to_viewer('flux-viewer', data_label)
     app.add_data_to_viewer('spectrum-viewer', data_label)

--- a/jdaviz/configs/cubeviz/plugins/parsers.py
+++ b/jdaviz/configs/cubeviz/plugins/parsers.py
@@ -133,7 +133,8 @@ def _parse_jwst_s3d(app, hdulist, data_label):
     unit = u.Unit(hdulist[1].header.get('BUNIT', 'count'))
     flux = hdulist[1].data << unit
     wcs = WCS(hdulist[1].header, hdulist)
-    data = Spectrum1D(flux, wcs=wcs)
+    sliced_wcs = wcs[:, 0, 0]  # Only want wavelengths
+    data = Spectrum1D(flux, wcs=sliced_wcs)
     app.add_data(data, data_label)
     app.add_data_to_viewer('flux-viewer', data_label)
     app.add_data_to_viewer('spectrum-viewer', data_label)


### PR DESCRIPTION
This is like #9 but using `Spectrum1D`. This approach is currently unsuccessful. Same traceback with both files provided by Brian Cherinka. This traceback is also reported by Derek Homeier in https://github.com/astropy/specutils/pull/874#issuecomment-929601708 .

```python
from jdaviz import Cubeviz

fn = 'Level2_det_image_seq1_MIRIFULONG_34LONGexp1_s3d.fits'
# fn = 'allcube_ch1-2-3-4-shortlongmedium-_s3d.fits'  # This too
viz = Cubeviz()
viz.load_data(fn)
```

```

.../jdaviz/core/helpers.py in load_data(self, data, parser_reference, **kwargs)
     44 
     45     def load_data(self, data, parser_reference=None, **kwargs):
---> 46         self.app.load_data(data, parser_reference=parser_reference, **kwargs)
     47 
     48     @property

.../jdaviz/app.py in load_data(self, file_obj, parser_reference, **kwargs)
    335                 # If the parser returns something other than known, assume it's
    336                 #  a message we want to make the user aware of.
--> 337                 msg = parser(self, file_obj, **kwargs)
    338 
    339                 if msg is not None:

.../jdaviz/configs/cubeviz/plugins/parsers.py in parse_data(app, file_obj, data_type, data_label)
     56                 # TODO: What about ERR, DQ, and WMAP?
     57                 data_label = f'{file_name}[SCI]'
---> 58                 _parse_jwst_s3d(app, hdulist, data_label)
     59             else:
     60                 _parse_hdu(app, hdulist, file_name=data_label or file_name)

.../jdaviz/configs/cubeviz/plugins/parsers.py in _parse_jwst_s3d(app, hdulist, data_label)
    134     flux = hdulist[1].data << unit
    135     wcs = WCS(hdulist[1].header, hdulist)
--> 136     data = Spectrum1D(flux, wcs=wcs)
    137     app.add_data(data, data_label)
    138     app.add_data_to_viewer('flux-viewer', data_label)

.../specutils/spectra/spectrum1d.py in __init__(self, flux, spectral_axis, wcs, velocity_convention,
rest_value, redshift, radial_velocity, bin_specification, **kwargs)
    205                     log.warn("Input WCS indicates that the spectral axis is not"
    206                              " last. Reshaping arrays to put spectral axis last.")
--> 207                     wcs = wcs.swapaxes(0, temp_axes[0])
    208                     if flux is not None:
    209                         flux = np.swapaxes(flux, len(flux.shape)-temp_axes[0]-1, -1)

.../astropy/wcs/wcs.py in swapaxes(self, ax0, ax1)
   3041         inds[ax0], inds[ax1] = inds[ax1], inds[ax0]
   3042 
-> 3043         return self.sub([i+1 for i in inds])
   3044 
   3045     def reorient_celestial_first(self):

.../astropy/wcs/wcs.py in sub(self, axes)
    594 
    595         # Subset the WCS
--> 596         copy.wcs = copy.wcs.sub(axes)
    597         copy.naxis = copy.wcs.naxis
    598 

InconsistentAxisTypesError: ERROR 4 in wcs_types() at line 3074 of file cextern/wcslib/C/wcs.c:
Table parameters set for non-table axis type.
```