### PR TITLE
Jt listener pre merge changes

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -9,7 +9,6 @@ try:
     from strauss.sources import Events
     from strauss.score import Score
     from strauss.generator import Spectralizer
-    from tqdm import tqdm
 except ImportError:
     pass
 
@@ -117,7 +116,7 @@ class CubeListenerData:
         lo2hi = self.wlens.argsort()[::-1]
 
         t0 = time.time()
-        for i in tqdm(range(self.cube.shape[0])):
+        for i in range(self.cube.shape[0]):
             for j in range(self.cube.shape[1]):
                 with suppress_stderr():
                     if self.cube[i, j, lo2hi].any():

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -13,7 +13,12 @@ __all__ = ['SonifyData']
 try:
     import strauss  # noqa
     import sounddevice as sd
-except ImportError:
+except ImportError as e:
+    class Empty:
+        pass
+    sd = Empty()
+    sd.default = Empty()
+    sd.default.device = [-1,-1]
     _has_strauss = False
 else:
     _has_strauss = True
@@ -54,7 +59,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         super().__init__(*args, **kwargs)
         self._plugin_description = 'Sonify a data cube'
         self.docs_description = 'Sonify a data cube using the Strauss package.'
-        if not self.has_strauss or len(sd.default.device) < 1:
+        if not self.has_strauss or sd.default.device[1] < 0:
             self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
                                  'can do this by running `pip install .[strauss]` in the command'
                                  ' line and then launching Jdaviz. Currently, this plugin only works'
@@ -64,6 +69,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             devices, indexes = self.build_device_lists()
             self.sound_device_indexes = dict(zip(devices, indexes))
             self.sound_devices_items = devices
+            print(dict(zip(indexes, devices)))
             self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
 
         # TODO: Remove hardcoded range and flux viewer

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -69,7 +69,6 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             devices, indexes = self.build_device_lists()
             self.sound_device_indexes = dict(zip(devices, indexes))
             self.sound_devices_items = devices
-            print(dict(zip(indexes, devices)))
             self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
 
         # TODO: Remove hardcoded range and flux viewer

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -61,7 +61,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         self.docs_description = 'Sonify a data cube using the Strauss package.'
         if not self.has_strauss or sd.default.device[1] < 0:
             self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
-                                 'can do this by running `pip install .[strauss]` in the command'
+                                 'can do this by running `pip install ".[strauss]"` in the command'
                                  ' line and then launching Jdaviz. Currently, this plugin only works'
                                  'on devices with valid sound output.')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ roman = [
     "roman_datamodels>=0.17.1",
 ]
 strauss = [
-    "strauss@git+https://github.com/james-trayford/strauss@equal_loudness_normalisation",
+    "strauss",
     "sounddevice"
 ]
 


### PR DESCRIPTION
- find a way to check for sound devices  in the no-`sounddevice` case using empty class and setting a value for `sd.default.device[1]` - think this works in all cases
- update pip suggestion for sonify plugin so it worked for me (cross-platform?)
- remove need for `tqdm`
- can use PyPI STRAUSS now (https://github.com/james-trayford/strauss/pull/36)!