### PR TITLE
fix dropouts

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -13,7 +13,8 @@ except ImportError:
     pass
 
 #  smallest fraction of the max audio amplitude that can be represented by a 16-bit signed integer
-MINVOL = 1/(2**15 - 1)
+INT_MAX = 2**15 - 1
+MINVOL = 1/INT_MAX
 
 
 @contextmanager
@@ -97,7 +98,8 @@ class CubeListenerData:
         self.cursig = np.zeros(self.siglen, dtype='int16')
         self.newsig = np.zeros(self.siglen, dtype='int16')
 
-        if self.cursig.nbytes * pow(1024, -3) > 2:
+        # ensure sigcube isn't too big before we initialise it
+        if self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -3) > 2:
             raise Exception("Cube projected to be > 2Gb!")
 
         self.sigcube = np.zeros((*self.cube.shape[:2], self.siglen), dtype='int16')

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -144,7 +144,10 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype('int16')
         elif vollim == 'buff':
             # renormalise buffer
-            self.sonified_cube.newsig = ((INT_MAX/abs(compsig).max())*compsig).astype('int16')
+            sigmax = abs(compsig).max()
+            if sigmax > INT_MAX:
+                compsig = ((INT_MAX/abs(compsig).max())*compsig)
+            self.sonified_cube.newsig = compsig.astype('int16')
         self.sonified_cube.cbuff = True
 
     def update_listener_wls(self, wranges, wunit):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -6,13 +6,14 @@ import numpy as np
 from astropy import units as u
 from astropy.nddata import CCDData
 from astropy.wcs import WCS
+from scipy.special import erf
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.cubeviz.plugins.mixins import WithSliceIndicator, WithSliceSelection
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
-from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL
+from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL, INT_MAX
 
 
 try:
@@ -122,17 +123,28 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         if self.stream and not self.stream.closed and self.stream_active:
             self.stream.stop()
 
-    def update_sonified_cube_with_coord(self, coord):
+    def update_sonified_cube_with_coord(self, coord, vollim='buff'):
         # Loop through all sonified layers and set newsig to the sound for each layer
         self.sonified_cube.newsig = np.zeros(self.sonified_cube.newsig.shape)
 
+        compsig = np.zeros(self.sonified_cube.newsig.size, dtype='int32')
         for k, v in self.uuid_lookup.items():
             # Each (x, y) coordinate corresponds to a different sound for each layer.
             # These sounds can be combined together and played by setting cbuff to True.
             # TODO: is there a better way to combine sounds or normalize them?
+            # TODO: apply 1/N or 1/N**0.5 normalisation per layer for N layers?
             if coord not in v:
                 continue
-            self.sonified_cube.newsig += v[coord]
+            compsig += v[coord]
+        if vollim == 'sig':
+            # sigmoidal volume limiting
+            self.sonified_cube.newsig = (erf(compsig/INT_MAX)* INT_MAX).astype('int16')
+        elif vollim == 'clip':
+            # hard-clipped volume limiting
+            self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype('int16')
+        elif vollim == 'buff':
+            # renormalise buffer
+            self.sonified_cube.newsig = ((INT_MAX/abs(compsig).max())*compsig).astype('int16')
         self.sonified_cube.cbuff = True
 
     def update_listener_wls(self, wranges, wunit):


### PR DESCRIPTION
'Crunchy' audio (dropouts) were due to overflowing/underflowing the `int16` limit when combining tracks, visualised here:

https://github.com/user-attachments/assets/c335b2d1-a62e-4c8e-85e7-deaafcbf488a

This can be treated in a variety of ways , hard clipping values introduces high frequency distortion:

https://github.com/user-attachments/assets/b70a8112-0467-4022-ad2f-861608bdf0ce

while using a sigmoid transfer function adds a low-freq rumble.

https://github.com/user-attachments/assets/f380c412-7030-4eb6-b105-be260ae7de37

Finally we can just normalise per buffer to ensure `MAX_INT` never exceeded

https://github.com/user-attachments/assets/64da0760-ddc0-430d-a077-b8f4c4378f32

This preserves the sound best but is renormalising audio so the volume-brightness coupling across the spatial field is clipped- but think this is the best option and have set it as default. Could remove the other approaches.

Also make sure the cube size warning is working correctly.

