### PR TITLE
In-browser sound

### DIFF
--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -13,7 +13,8 @@ except ImportError:
     pass
 
 #  smallest fraction of the max audio amplitude that can be represented by a 16-bit signed integer
-MINVOL = 1/(2**15 - 1)
+INT_MAX = 2**15 - 1
+MINVOL = 1/INT_MAX
 
 
 @contextmanager
@@ -97,7 +98,8 @@ class CubeListenerData:
         self.cursig = np.zeros(self.siglen, dtype='int16')
         self.newsig = np.zeros(self.siglen, dtype='int16')
 
-        if self.cursig.nbytes * pow(1024, -3) > 2:
+        # ensure sigcube isn't too big before we initialise it
+        if self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -3) > 2:
             raise Exception("Cube projected to be > 2Gb!")
 
         self.sigcube = np.zeros((*self.cube.shape[:2], self.siglen), dtype='int16')

--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -8,7 +8,7 @@ try:
     from strauss.sonification import Sonification
     from strauss.sources import Events
     from strauss.score import Score
-    from strauss.generator import Spectralizer
+    from strauss.generator import Spectralizer, Synthesizer
 except ImportError:
     pass
 
@@ -27,7 +27,49 @@ def suppress_stderr():
         finally:
             sys.stderr = old_stderr
 
+def make_notification_sounds(srate=44100, duration=0.5):
+    # fifth interval - commonly evokes 'ready'
+    notes = [["E3", "B3", "E4"]]
+    score = Score(notes, duration)
+    generator = Synthesizer(samprate=srate)
+    
+    generator.load_preset('pitch_mapper')
 
+    # play interval in sequence
+    data_on = {'time': [0,0.2, 0.4], 'pitch': [0,1,2]}
+    data_off = {'time': [0.4,0.2, 0.], 'pitch': [0,1,2]}
+    lims = {'time': (0, 1)}
+    generator.modify_preset({'note_length':1,
+                             'filter':'on',
+                             'cutoff': 0.6,
+                             'volume_envelope': {'use':'on',
+                                                 'A':0.02, 'D':0.2, 'S':0}
+                             })
+    # set up source
+    sources_on = Events(data_on.keys())
+    sources_on.fromdict(data_on)
+    sources_on.apply_mapping_functions(map_lims=lims)
+
+    sources_off = Events(data_off.keys())
+    sources_off.fromdict(data_off)
+    sources_off.apply_mapping_functions(map_lims=lims)
+    
+    # render and play sonification!
+    on = Sonification(score, sources_on, generator, 'mono', samprate=srate)
+    off = Sonification(score, sources_off, generator, 'mono', samprate=srate)
+    on.render()
+    off.render()
+
+    notif_audio = {'on' : on.out_channels['0'].values,
+                   'off': off.out_channels['0'].values
+                   }
+
+    for k in notif_audio.keys():
+        sig = notif_audio[k]
+        notif_audio[k] = (INT_MAX * sig / abs(sig).max()).astype('int16')
+    print("made notifications...")
+    return notif_audio
+            
 def sonify_spectrum(spec, duration, overlap=0.05, system='mono', srate=44100, fmin=40, fmax=1300,
                     eln=False):
     notes = [["A2"]]
@@ -72,6 +114,9 @@ class CubeListenerData:
         self.maxval = pow(2, bdepth-1) - 1
         self.fadedx = 0
 
+        # generate notification audio
+        self.notification_sounds = make_notification_sounds(srate=44100, duration=0.5)
+        
         if vol is None:
             self.atten_level = 1
         else:

--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -98,6 +98,7 @@ class CubeListenerData:
         self.cursig = np.zeros(self.siglen, dtype='int16')
         self.newsig = np.zeros(self.siglen, dtype='int16')
 
+        print(self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -2))
         # ensure sigcube isn't too big before we initialise it
         if self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -3) > 2:
             raise Exception("Cube projected to be > 2Gb!")
@@ -135,7 +136,7 @@ class CubeListenerData:
         self.cursig[:] = self.sigcube[self.idx1, self.idx2, :]
         self.newsig[:] = self.cursig[:]
         t1 = time.time()
-        print(f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels")
+        print(f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels for {self.cube.shape[0]*self.cube.shape[1]*self.sigcube.shape[-1] * 2 * pow(1024, -2)} Mb ({self.sigcube.shape[0]}x{self.sigcube.shape[1]}x{self.sigcube.shape[-1]})")
 
     def player_callback(self, outdata, frames, time, status):
         cur = self.cursig

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -2,6 +2,7 @@ from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
 import os
 
+from base64 import b64encode
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
@@ -60,6 +61,10 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     sound_devices_items = List().tag(sync=True)
     sound_devices_selected = Unicode('').tag(sync=True)
 
+    # SFX
+    sound_in = Unicode('').tag(sync=True)
+    sound_out = Unicode('').tag(sync=True)
+    
     # some addiional attributes for JS
     first_sonification_done = Bool(False).tag(sync=True)
     thisfile = Unicode(SOUND_DIR).tag(sync=True)
@@ -81,6 +86,9 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         # TODO: Remove hardcoded range and flux viewer
         self.spec_viewer = self.app.get_viewer('spectrum-viewer')
         self.flux_viewer = self.app.get_viewer('flux-viewer')
+
+        # with open(os.path.join(SOUND_DIR, 'in.mp3')) as f:
+        #     self.sound_in = f"data:audio/mpeg;base64,{b64encode(f.read).decode('utf-8')}"
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -1,6 +1,7 @@
 from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
 import os
+from io import BytesIO
 
 from base64 import b64encode
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
@@ -13,8 +14,9 @@ from jdaviz.core.user_api import PluginUserApi
 __all__ = ['SonifyData']
 
 try:
-    import strauss  # noqa
+    import strauss
     import sounddevice as sd
+    from scipy.io.wavfile import write as write_wav
 except ImportError:
     class Empty:
         pass
@@ -56,6 +58,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     volume = IntHandleEmpty(100).tag(sync=True)
     stream_active = Bool(True).tag(sync=True)
     has_strauss = Bool(_has_strauss).tag(sync=True)
+    has_outs = Bool((sd.default.device[1] != -1)).tag(sync=True)
 
     # TODO: can we refresh the list, so sounddevices are up-to-date when dropdown clicked?
     sound_devices_items = List().tag(sync=True)
@@ -64,7 +67,8 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     # SFX
     sound_in = Unicode('').tag(sync=True)
     sound_out = Unicode('').tag(sync=True)
-    
+    sonified_audio_data = Unicode('').tag(sync=True)
+
     # some addiional attributes for JS
     first_sonification_done = Bool(False).tag(sync=True)
     thisfile = Unicode(SOUND_DIR).tag(sync=True)
@@ -73,7 +77,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         super().__init__(*args, **kwargs)
         self._plugin_description = 'Sonify a data cube'
         self.docs_description = 'Sonify a data cube using the Strauss package.'
-        if not self.has_strauss or sd.default.device[1] < 0:
+        if not self.has_strauss:
             self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
                                  'can do this by running pip install strauss in the command'
                                  ' line and then launching Jdaviz. Currently, this plugin only'
@@ -101,8 +105,11 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             raise ValueError('Unable to sonify cube')
 
         # Get index of selected device
-        selected_device_index = self.sound_device_indexes[self.sound_devices_selected]
-
+        if self.sound_devices_selected:
+            selected_device_index = self.sound_device_indexes[self.sound_devices_selected]
+        else:
+            selected_device_index = None
+            
         # Apply spectral subset bounds
         if self.spectral_subset_selected is not self.spectral_subset.default_text:
             display_unit = self.spec_viewer.state.x_display_unit
@@ -113,10 +120,17 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         # Ensure the current spectral region bounds are up-to-date at render time
         self.update_wavelength_range(None)
         # generate the sonified cube
-        self.flux_viewer.get_sonified_cube(self.sample_rate, self.buffer_size,
+        sonified_data = self.flux_viewer.get_sonified_cube(self.sample_rate, self.buffer_size,
                                            selected_device_index, self.assidx, self.ssvidx,
                                            self.pccut, self.audfrqmin,
                                            self.audfrqmax, self.eln, self.use_pccut)
+        
+        # In-memory WAV file
+        wav_buffer = BytesIO()
+        write_wav(wav_buffer, self.sample_rate, self.flux_viewer.sonified_cube.notification_sounds['on'].astype('int16'))
+        wav_buffer.seek(0)
+
+        self.sonified_audio_data = b64encode(wav_buffer.read()).decode('utf-8')
         self.first_sonification_done = True
 
     def vue_start_stop_stream(self, *args):
@@ -149,7 +163,10 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         devices, indexes = self.build_device_lists()
         self.sound_device_indexes = dict(zip(devices, indexes))
         self.sound_devices_items = devices
-        self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
+        if len(devices) > 0:
+            self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
+        else:
+            self.sound_devices_selected = ''
 
     def vue_refresh_device_list_in_dropdown(self, *args):
         self.refresh_device_list()

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -1,5 +1,6 @@
-from traitlets import Bool, List, Unicode, observe
+from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
+import os
 
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
@@ -23,6 +24,8 @@ except ImportError:
 else:
     _has_strauss = True
 
+# TODO: create this directory for stock sounds?
+SOUND_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'data', 'sounds')
 
 @tray_registry('cubeviz-sonify-data', label="Sonify Data",
                viewer_requirements=['spectrum', 'image'])
@@ -53,9 +56,13 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     stream_active = Bool(True).tag(sync=True)
     has_strauss = Bool(_has_strauss).tag(sync=True)
 
-    # TODO: can we referesh the list, so sounddevices are up-to-date when dropdown clicked?
+    # TODO: can we refresh the list, so sounddevices are up-to-date when dropdown clicked?
     sound_devices_items = List().tag(sync=True)
     sound_devices_selected = Unicode('').tag(sync=True)
+
+    # some addiional attributes for JS
+    first_sonification_done = Bool(False).tag(sync=True)
+    thisfile = Unicode(SOUND_DIR).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -102,6 +109,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
                                            selected_device_index, self.assidx, self.ssvidx,
                                            self.pccut, self.audfrqmin,
                                            self.audfrqmax, self.eln, self.use_pccut)
+        self.first_sonification_done = True
 
     def vue_start_stop_stream(self, *args):
         self.stream_active = not self.stream_active

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
@@ -14,6 +14,10 @@
       To use Sonify Data, install strauss and restart Jdaviz. You can do this by running pip install strauss
       in the command line and then launching Jdaviz.
     </v-alert>
+    <v-row v-if="has_strauss && !has_outs">
+      <j-docs-link>Sonification on platforms is under construction, and will be silent for now.</j-docs-link>
+    </v-row>
+
     <v-row>
       <j-docs-link>Choose the input cube, spectral subset and any advanced sonification options.</j-docs-link>
     </v-row>
@@ -162,44 +166,54 @@
   export default {
     methods: {
       handleSonifyClick() {
-	// multipurpose function on click - this writes to the browser JS console
-	console.log('Run Sonify Cube...')
-	this.sonify_cube(); // First render sonification...
-      },
-      async setupAudio() {
-	// two birds with one stone - as well as rendering the sonification, the browser
-	// can use the "Sonify Data" button press as the gesture your browser needs in-page
-	// before allowing browser playback...
-	console.log('Take clicking Sonify Data as gesture to initialise Audio Context...');
-	audioContext = await new (window.AudioContext || window.webkitAudioContext)();
-	await this.loadAudio();
+        // multipurpose function on click - this writes to the browser JS console
+        console.log('Run Sonify Cube...')
+        if (!this.audioContext) {
+          console.log('Creating AudioContext...');
+          this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        this.sonify_cube(); // First render sonification...
       },
       async loadAudio() {
         try {
-	  // Once sonified cube is rendered, for now just play coin sound as an affirmation
-	  // this sound is now being rendered by the browser (not streamed to a sound device by
-	  // python) so should be possible on platforms.
-          const response = await fetch('https://archive.org/download/Castle_2015102/Coin.mp3');
-          const arrayBuffer = await response.arrayBuffer();
-          audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-	  sourceNode = audioContext.createBufferSource();
-          sourceNode.buffer = audioBuffer;
-	  sourceNode.connect(audioContext.destination);
-          sourceNode.start(0);
+          // Once sonified cube is rendered, for now just play coin sound as an affirmation
+          // this sound is now being rendered by the browser (not streamed to a sound device by
+          // python) so should be possible on platforms.
+          console.log('New audio data incoming...')
+          const arrayBuffer = this.sonified_audio_data_str.buffer;
+          this.audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+
+          // 1. Create a GainNode to control volume
+          const gainNode = this.audioContext.createGain();
+          gainNode.gain.value = 0.5; 
+          gainNode.connect(this.audioContext.destination);
+          
+          this.sourceNode = this.audioContext.createBufferSource();
+          this.sourceNode.buffer = this.audioBuffer;
+          this.sourceNode.connect(gainNode);
+          this.sourceNode.start(0);
         } catch (error) {
-          console.error('Audio load error:', error);
-          throw error;
+            console.error('Audio load error:', error);
+            throw error;
         }
       }
     },
     watch: {
-      first_sonification_done(newVal) {
-	// we wait for confirmation the cube has been rendered
-	if (newVal && this.first_sonification_done === true) {
-	  this.setupAudio();
-	  // reset flag so it triggers if we render again...
-	  this.first_sonification_done = false;
-	}
+      sonified_audio_data(newVal) {
+        if (newVal) {
+          this.loadAudio();
+        }
+      }
+    },
+    computed: {
+      sonified_audio_data_str() {
+        const binary_string = window.atob(this.sonified_audio_data);
+        const len = binary_string.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+          bytes[i] = binary_string.charCodeAt(i);
+        }
+        return bytes;
       }
     }
   }

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
@@ -116,7 +116,7 @@
     <v-row>
       <plugin-action-button
         :spinner="spinner"
-        @click="sonify_cube"
+        @click="handleSonifyClick"
       >
         Sonify data
       </plugin-action-button>
@@ -155,3 +155,52 @@
    </v-row>
  </j-tray-plugin>
 </template>
+
+<script>
+  // from the Sonify Plugin we can use the WebAudio API for detailed in-browser
+  // control over audio playback.
+  export default {
+    methods: {
+      handleSonifyClick() {
+	// multipurpose function on click - this writes to the browser JS console
+	console.log('Run Sonify Cube...')
+	this.sonify_cube(); // First render sonification...
+      },
+      async setupAudio() {
+	// two birds with one stone - as well as rendering the sonification, the browser
+	// can use the "Sonify Data" button press as the gesture your browser needs in-page
+	// before allowing browser playback...
+	console.log('Take clicking Sonify Data as gesture to initialise Audio Context...');
+	audioContext = await new (window.AudioContext || window.webkitAudioContext)();
+	await this.loadAudio();
+      },
+      async loadAudio() {
+        try {
+	  // Once sonified cube is rendered, for now just play coin sound as an affirmation
+	  // this sound is now being rendered by the browser (not streamed to a sound device by
+	  // python) so should be possible on platforms.
+          const response = await fetch('https://archive.org/download/Castle_2015102/Coin.mp3');
+          const arrayBuffer = await response.arrayBuffer();
+          audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+	  sourceNode = audioContext.createBufferSource();
+          sourceNode.buffer = audioBuffer;
+	  sourceNode.connect(audioContext.destination);
+          sourceNode.start(0);
+        } catch (error) {
+          console.error('Audio load error:', error);
+          throw error;
+        }
+      }
+    },
+    watch: {
+      first_sonification_done(newVal) {
+	// we wait for confirmation the cube has been rendered
+	if (newVal && this.first_sonification_done === true) {
+	  this.setupAudio();
+	  // reset flag so it triggers if we render again...
+	  this.first_sonification_done = false;
+	}
+      }
+    }
+  }
+</script>

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -144,7 +144,10 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype('int16')
         elif vollim == 'buff':
             # renormalise buffer
-            self.sonified_cube.newsig = ((INT_MAX/abs(compsig).max())*compsig).astype('int16')
+            sigmax = abs(compsig).max()
+            if sigmax > INT_MAX:
+                compsig = ((INT_MAX/abs(compsig).max())*compsig)
+            self.sonified_cube.newsig = compsig.astype('int16')
         self.sonified_cube.cbuff = True
 
     def update_listener_wls(self, wranges, wunit):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -6,13 +6,14 @@ import numpy as np
 from astropy import units as u
 from astropy.nddata import CCDData
 from astropy.wcs import WCS
+from scipy.special import erf
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.cubeviz.plugins.mixins import WithSliceIndicator, WithSliceSelection
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
-from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL
+from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL, INT_MAX
 
 
 try:
@@ -122,17 +123,28 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         if self.stream and not self.stream.closed and self.stream_active:
             self.stream.stop()
 
-    def update_sonified_cube_with_coord(self, coord):
+    def update_sonified_cube_with_coord(self, coord, vollim='buff'):
         # Loop through all sonified layers and set newsig to the sound for each layer
         self.sonified_cube.newsig = np.zeros(self.sonified_cube.newsig.shape)
 
+        compsig = np.zeros(self.sonified_cube.newsig.size, dtype='int32')
         for k, v in self.uuid_lookup.items():
             # Each (x, y) coordinate corresponds to a different sound for each layer.
             # These sounds can be combined together and played by setting cbuff to True.
             # TODO: is there a better way to combine sounds or normalize them?
+            # TODO: apply 1/N or 1/N**0.5 normalisation per layer for N layers?
             if coord not in v:
                 continue
-            self.sonified_cube.newsig += v[coord]
+            compsig += v[coord]
+        if vollim == 'sig':
+            # sigmoidal volume limiting
+            self.sonified_cube.newsig = (erf(compsig/INT_MAX)* INT_MAX).astype('int16')
+        elif vollim == 'clip':
+            # hard-clipped volume limiting
+            self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype('int16')
+        elif vollim == 'buff':
+            # renormalise buffer
+            self.sonified_cube.newsig = ((INT_MAX/abs(compsig).max())*compsig).astype('int16')
         self.sonified_cube.cbuff = True
 
     def update_listener_wls(self, wranges, wunit):

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -202,7 +202,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             # and re-clip
             clipped_arr = np.clip(clipped_arr, 0, np.inf)
 
-        self.sonified_cube = CubeListenerData(clipped_arr ** assidx, wlens, duration=0.8,
+        self.sonified_cube = CubeListenerData(clipped_arr ** assidx, wlens, duration=0.2,
                                               samplerate=sample_rate, buffsize=buffer_size,
                                               wl_unit=self.sonification_wl_unit,
                                               audfrqmin=audfrqmin, audfrqmax=audfrqmax,

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -15,12 +15,24 @@ from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
 from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL, INT_MAX
 
-
+_has_sound = True
 try:
     import sounddevice as sd
+    if sd.default.device['output'] < 0:
+        _has_sound = False
 except ImportError:
-    pass
-
+    _has_sound = False
+if not _has_sound:
+    class DummySoundDevice:
+        class OutputStream:
+            def __init__(self, **kwargs):
+                self.closed = False
+            def stop(self):
+                self.closed = True
+            def start(self):    
+                self.closed = False
+    sd = DummySoundDevice()
+    
 __all__ = ['CubevizImageView', 'CubevizProfileView']
 
 
@@ -244,6 +256,8 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         # Set opacity to 0
         [layer for layer in self.state.layers if layer.layer.label == data_name][0].alpha = 0
 
+        return self.sonified_cube.sigcube
+        
     def _viewer_mouse_event(self, data):
         if data['event'] in ('mouseleave', 'mouseenter'):
             self.stop_stream()


### PR DESCRIPTION
building on https://github.com/javerbukh/jdaviz/pull/24

For the sound to work on platforms like MAST, we need a different way of doing audio - we can't just send samples directly to the sound card as we do in python. To do this, we can use the clients browser to play the audio, but need to be able to finely manipulate playback in JS. for this we use the `WebAudio` API. 

Simple implementation here sonifies the data as usual, and sets up the audio to play through python, but also affirms this audio i loaded with a sound effect, loaded from the web and played using `WebAudio` 

If this a sound approach, we can trial this approach for  client-side sonified cube rendering, building on the pure-JS audio handling I've been experimenting with outside Jdaviz

Some outstanding questions:
* Is it ok the have the `sonify_cub.vue` execute javascript as here? If not where could it go?
* Can the approach of generating an audio file representing the sonified cube and revealing to the user for their session (perhaps using a UUID-named sound file hosted on e.g. MAST)
* Can we save stock sounds (as we do icons) in the resources directory? How can we make these visible to the client?

Another approach being investigated is `WebRTC` to stream from server to client

