### PR TITLE
treat ImageHDU as HDUList with single extension

### DIFF
--- a/jdaviz/configs/imviz/helper.py
+++ b/jdaviz/configs/imviz/helper.py
@@ -203,13 +203,6 @@ class Imviz(ImageConfigHelper):
                                     and not data_label.endswith(']')
                                     and getattr(data, 'meta', {}).get('plugin', None) is None)
 
-            if isinstance(data, fits.hdu.image.ImageHDU) and data_label_as_prefix:
-                # extensions are not handled by loaders for an ImageHDU
-                # TODO: move this logic into the image importer and treat it
-                # as an HDUList with a single extension
-                data_label = data_label + f'[{data.name},{data.ver}]'
-                data_label_as_prefix = False
-
             self._load(data,
                        format='Image',
                        data_label=data_label,


### PR DESCRIPTION
this pull request avoids a hacky workaround in `load_data` by treating any `ImageHDU` input the same as an `HDUList` with a single available extension.