### PR TITLE
Browser sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+
+## [Unreleased]
+
+### Features
+
+- Modified the Sonify Data plugin to send audio data from the server to the client for playback in the browser.
+- The Python backend now generates a `.wav` notification in memory using strauss, encodes it in base64, and sends it to the frontend.
+- The Vue.js frontend now decodes the base64 audio data and plays it using the Web Audio API.

--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -8,7 +8,7 @@ try:
     from strauss.sonification import Sonification
     from strauss.sources import Events
     from strauss.score import Score
-    from strauss.generator import Spectralizer
+    from strauss.generator import Spectralizer, Synthesizer
 except ImportError:
     pass
 
@@ -27,7 +27,49 @@ def suppress_stderr():
         finally:
             sys.stderr = old_stderr
 
+def make_notification_sounds(srate=44100, duration=0.5):
+    # fifth interval - commonly evokes 'ready'
+    notes = [["E3", "B3", "E4"]]
+    score = Score(notes, duration)
+    generator = Synthesizer(samprate=srate)
+    
+    generator.load_preset('pitch_mapper')
 
+    # play interval in sequence
+    data_on = {'time': [0,0.2, 0.4], 'pitch': [0,1,2]}
+    data_off = {'time': [0.4,0.2, 0.], 'pitch': [0,1,2]}
+    lims = {'time': (0, 1)}
+    generator.modify_preset({'note_length':1,
+                             'filter':'on',
+                             'cutoff': 0.6,
+                             'volume_envelope': {'use':'on',
+                                                 'A':0.02, 'D':0.2, 'S':0}
+                             })
+    # set up source
+    sources_on = Events(data_on.keys())
+    sources_on.fromdict(data_on)
+    sources_on.apply_mapping_functions(map_lims=lims)
+
+    sources_off = Events(data_off.keys())
+    sources_off.fromdict(data_off)
+    sources_off.apply_mapping_functions(map_lims=lims)
+    
+    # render and play sonification!
+    on = Sonification(score, sources_on, generator, 'mono', samprate=srate)
+    off = Sonification(score, sources_off, generator, 'mono', samprate=srate)
+    on.render()
+    off.render()
+
+    notif_audio = {'on' : on.out_channels['0'].values,
+                   'off': off.out_channels['0'].values
+                   }
+
+    for k in notif_audio.keys():
+        sig = notif_audio[k]
+        notif_audio[k] = (INT_MAX * sig / abs(sig).max()).astype('int16')
+    print("made notifications...")
+    return notif_audio
+            
 def sonify_spectrum(spec, duration, overlap=0.05, system='mono', srate=44100, fmin=40, fmax=1300,
                     eln=False):
     notes = [["A2"]]
@@ -72,6 +114,9 @@ class CubeListenerData:
         self.maxval = pow(2, bdepth-1) - 1
         self.fadedx = 0
 
+        # generate notification audio
+        self.notification_sounds = make_notification_sounds(srate=44100, duration=0.5)
+        
         if vol is None:
             self.atten_level = 1
         else:

--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -14,7 +14,7 @@ except ImportError:
 
 #  smallest fraction of the max audio amplitude that can be represented by a 16-bit signed integer
 INT_MAX = 2**15 - 1
-MINVOL = 1/INT_MAX
+MINVOL = 1 / INT_MAX
 
 
 @contextmanager
@@ -27,24 +27,27 @@ def suppress_stderr():
         finally:
             sys.stderr = old_stderr
 
+
 def make_notification_sounds(srate=44100, duration=0.5):
     # fifth interval - commonly evokes 'ready'
     notes = [["E3", "B3", "E4"]]
     score = Score(notes, duration)
     generator = Synthesizer(samprate=srate)
-    
-    generator.load_preset('pitch_mapper')
+
+    generator.load_preset("pitch_mapper")
 
     # play interval in sequence
-    data_on = {'time': [0,0.2, 0.4], 'pitch': [0,1,2]}
-    data_off = {'time': [0.4,0.2, 0.], 'pitch': [0,1,2]}
-    lims = {'time': (0, 1)}
-    generator.modify_preset({'note_length':1,
-                             'filter':'on',
-                             'cutoff': 0.6,
-                             'volume_envelope': {'use':'on',
-                                                 'A':0.02, 'D':0.2, 'S':0}
-                             })
+    data_on = {"time": [0, 0.2, 0.4], "pitch": [0, 1, 2]}
+    data_off = {"time": [0.4, 0.2, 0.0], "pitch": [0, 1, 2]}
+    lims = {"time": (0, 1)}
+    generator.modify_preset(
+        {
+            "note_length": 1,
+            "filter": "on",
+            "cutoff": 0.6,
+            "volume_envelope": {"use": "on", "A": 0.02, "D": 0.2, "S": 0},
+        }
+    )
     # set up source
     sources_on = Events(data_on.keys())
     sources_on.fromdict(data_on)
@@ -53,42 +56,57 @@ def make_notification_sounds(srate=44100, duration=0.5):
     sources_off = Events(data_off.keys())
     sources_off.fromdict(data_off)
     sources_off.apply_mapping_functions(map_lims=lims)
-    
+
     # render and play sonification!
-    on = Sonification(score, sources_on, generator, 'mono', samprate=srate)
-    off = Sonification(score, sources_off, generator, 'mono', samprate=srate)
+    on = Sonification(score, sources_on, generator, "mono", samprate=srate)
+    off = Sonification(score, sources_off, generator, "mono", samprate=srate)
     on.render()
     off.render()
 
-    notif_audio = {'on' : on.out_channels['0'].values,
-                   'off': off.out_channels['0'].values
-                   }
+    notif_audio = {
+        "on": on.out_channels["0"].values,
+        "off": off.out_channels["0"].values,
+    }
 
     for k in notif_audio.keys():
         sig = notif_audio[k]
-        notif_audio[k] = (INT_MAX * sig / abs(sig).max()).astype('int16')
+        notif_audio[k] = (INT_MAX * sig / abs(sig).max()).astype("int16")
     print("made notifications...")
     return notif_audio
-            
-def sonify_spectrum(spec, duration, overlap=0.05, system='mono', srate=44100, fmin=40, fmax=1300,
-                    eln=False):
+
+
+def sonify_spectrum(
+    spec,
+    duration,
+    overlap=0.05,
+    system="mono",
+    srate=44100,
+    fmin=40,
+    fmax=1300,
+    eln=False,
+):
     notes = [["A2"]]
     score = Score(notes, duration)
     # set up spectralizer generator
     generator = Spectralizer(samprate=srate)
 
     # Lets pick the mapping frequency range for the spectrum...
-    generator.modify_preset({'min_freq': fmin, 'max_freq': fmax,
-                             'fit_spec_multiples': False,
-                             'interpolation_type': 'preserve_power',
-                             'equal_loudness_normalisation': eln})
+    generator.modify_preset(
+        {
+            "min_freq": fmin,
+            "max_freq": fmax,
+            "fit_spec_multiples": False,
+            "interpolation_type": "preserve_power",
+            "equal_loudness_normalisation": eln,
+        }
+    )
 
-    data = {'spectrum': [spec], 'pitch': [1]}
+    data = {"spectrum": [spec], "pitch": [1]}
 
     # set range in spectral flux representing the maximum and minimum sound frequency power:
     # 0 (numeric): absolute 0 in flux units, such that any flux above 0 will sound.
     # '100' (string): 100th percentile (i.e. maximum value) in spectral flux.
-    lims = {'spectrum': (0, '%100')}
+    lims = {"spectrum": (0, "%100")}
 
     # set up source
     sources = Events(data.keys())
@@ -100,33 +118,46 @@ def sonify_spectrum(spec, duration, overlap=0.05, system='mono', srate=44100, fm
     soni.render()
     soni._make_seamless(overlap)
 
-    return soni.loop_channels['0'].values
+    return soni.loop_channels["0"].values
 
 
 class CubeListenerData:
-    def __init__(self, cube, wlens, samplerate=44100, duration=1, overlap=0.05, buffsize=1024,
-                 bdepth=16, wl_unit=None, audfrqmin=50, audfrqmax=1500, eln=False, vol=None):
-        self.siglen = int(samplerate*(duration-overlap))
+    def __init__(
+        self,
+        cube,
+        wlens,
+        samplerate=44100,
+        duration=1,
+        overlap=0.05,
+        buffsize=1024,
+        bdepth=16,
+        wl_unit=None,
+        audfrqmin=50,
+        audfrqmax=1500,
+        eln=False,
+        vol=None,
+    ):
+        self.siglen = int(samplerate * (duration - overlap))
         self.cube = cube
         self.dur = duration
         self.bdepth = bdepth
         self.srate = samplerate
-        self.maxval = pow(2, bdepth-1) - 1
+        self.maxval = pow(2, bdepth - 1) - 1
         self.fadedx = 0
 
         # generate notification audio
         self.notification_sounds = make_notification_sounds(srate=44100, duration=0.5)
-        
+
         if vol is None:
             self.atten_level = 1
         else:
-            self.atten_level = int(np.clip((vol/100)**2, MINVOL, 1))
+            self.atten_level = int(np.clip((vol / 100) ** 2, MINVOL, 1))
 
         self.wl_unit = wl_unit
         self.wlens = wlens
 
         # control fades
-        fade = np.linspace(0, 1, buffsize+1)
+        fade = np.linspace(0, 1, buffsize + 1)
         self.ifade = fade[:-1]
         self.ofade = fade[::-1][:-1]
 
@@ -140,15 +171,15 @@ class CubeListenerData:
         self.idx1 = 0
         self.idx2 = 0
         self.cbuff = False
-        self.cursig = np.zeros(self.siglen, dtype='int16')
-        self.newsig = np.zeros(self.siglen, dtype='int16')
+        self.cursig = np.zeros(self.siglen, dtype="int16")
+        self.newsig = np.zeros(self.siglen, dtype="int16")
 
-        print(self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -2))
+        print(self.cube[:, :, 0].size * self.siglen * 2 * pow(1024, -2))
         # ensure sigcube isn't too big before we initialise it
         if self.cube[:, :, 0].size * self.siglen * 2 * pow(1024, -3) > 2:
             raise Exception("Cube projected to be > 2Gb!")
 
-        self.sigcube = np.zeros((*self.cube.shape[:2], self.siglen), dtype='int16')
+        self.sigcube = np.zeros((*self.cube.shape[:2], self.siglen), dtype="int16")
 
     def set_wl_bounds(self, w1, w2):
         """
@@ -169,28 +200,35 @@ class CubeListenerData:
             for j in range(self.cube.shape[1]):
                 with suppress_stderr():
                     if self.cube[i, j, lo2hi].any():
-                        sig = sonify_spectrum(self.cube[i, j, lo2hi], self.dur,
-                                              srate=self.srate,
-                                              fmin=self.audfrqmin,
-                                              fmax=self.audfrqmax,
-                                              eln=self.eln)
-                        sig = (sig*self.maxval).astype('int16')
+                        sig = sonify_spectrum(
+                            self.cube[i, j, lo2hi],
+                            self.dur,
+                            srate=self.srate,
+                            fmin=self.audfrqmin,
+                            fmax=self.audfrqmax,
+                            eln=self.eln,
+                        )
+                        sig = (sig * self.maxval).astype("int16")
                         self.sigcube[i, j, :] = sig
                     else:
                         continue
         self.cursig[:] = self.sigcube[self.idx1, self.idx2, :]
         self.newsig[:] = self.cursig[:]
         t1 = time.time()
-        print(f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels for {self.cube.shape[0]*self.cube.shape[1]*self.sigcube.shape[-1] * 2 * pow(1024, -2)} Mb ({self.sigcube.shape[0]}x{self.sigcube.shape[1]}x{self.sigcube.shape[-1]})")
+        print(
+            f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels for "
+            f"{self.cube.shape[0]*self.cube.shape[1]*self.sigcube.shape[-1] * 2*pow(1024, -2)} Mb"
+            f" ({self.sigcube.shape[0]}x{self.sigcube.shape[1]}x{self.sigcube.shape[-1]})"
+        )
 
     def player_callback(self, outdata, frames, time, status):
         cur = self.cursig
         new = self.newsig
-        sdx = int(time.outputBufferDacTime*self.srate)
-        dxs = np.arange(sdx, sdx+frames).astype(int) % self.sigcube.shape[-1]
+        sdx = int(time.outputBufferDacTime * self.srate)
+        dxs = np.arange(sdx, sdx + frames).astype(int) % self.sigcube.shape[-1]
         if self.cbuff:
-            outdata[:, 0] = (cur[dxs] * self.ofade).astype('int16')
-            outdata[:, 0] += (new[dxs] * self.ifade).astype('int16')
+            outdata[:, 0] = (cur[dxs] * self.ofade).astype("int16")
+            outdata[:, 0] += (new[dxs] * self.ifade).astype("int16")
             self.cursig[:] = self.newsig[:]
             self.cbuff = False
         else:

--- a/jdaviz/configs/cubeviz/plugins/cube_listener.py
+++ b/jdaviz/configs/cubeviz/plugins/cube_listener.py
@@ -98,6 +98,7 @@ class CubeListenerData:
         self.cursig = np.zeros(self.siglen, dtype='int16')
         self.newsig = np.zeros(self.siglen, dtype='int16')
 
+        print(self.cube[:,:,0].size * self.siglen * 2 * pow(1024, -2))
         # ensure sigcube isn't too big before we initialise it
         if self.cube[:, :, 0].size * self.siglen * 2 * pow(1024, -3) > 2:
             raise Exception("Cube projected to be > 2Gb!")
@@ -135,7 +136,7 @@ class CubeListenerData:
         self.cursig[:] = self.sigcube[self.idx1, self.idx2, :]
         self.newsig[:] = self.cursig[:]
         t1 = time.time()
-        print(f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels")
+        print(f"Took {t1-t0}s to process {self.cube.shape[0]*self.cube.shape[1]} spaxels for {self.cube.shape[0]*self.cube.shape[1]*self.sigcube.shape[-1] * 2 * pow(1024, -2)} Mb ({self.sigcube.shape[0]}x{self.sigcube.shape[1]}x{self.sigcube.shape[-1]})")
 
     def player_callback(self, outdata, frames, time, status):
         cur = self.cursig

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -26,7 +26,7 @@ except ImportError:
     _has_strauss = False
 try:
     import sounddevice as sd
-except ImportError:
+except (ImportError, OSError):
 
     class Empty:
         pass
@@ -34,7 +34,8 @@ except ImportError:
     sd = Empty()
     sd.default = Empty()
     sd.default.device = [-1, -1]
-
+    sd.query_devices = lambda: []
+    
 # TODO: create this directory for stock sounds?
 SOUND_DIR = os.path.join(
     os.path.dirname(__file__), "..", "..", "..", "..", "data", "sounds"

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -1,4 +1,4 @@
-from traitlets import Unicode, Bool, List, Unicode, observe
+from traitlets import Bool, List, Unicode, observe
 import astropy.units as u
 import os
 from io import BytesIO
@@ -6,13 +6,17 @@ from io import BytesIO
 from base64 import b64encode
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
-from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
-                                        SpectralSubsetSelectMixin, with_spinner,
-                                        AddResultsMixin)
+from jdaviz.core.template_mixin import (
+    PluginTemplateMixin,
+    DatasetSelectMixin,
+    SpectralSubsetSelectMixin,
+    with_spinner,
+    AddResultsMixin,
+)
 from jdaviz.core.user_api import PluginUserApi
 
 
-__all__ = ['SonifyData']
+__all__ = ["SonifyData"]
 
 try:
     import strauss
@@ -23,18 +27,24 @@ except ImportError:
 try:
     import sounddevice as sd
 except ImportError:
+
     class Empty:
         pass
+
     sd = Empty()
     sd.default = Empty()
     sd.default.device = [-1, -1]
 
 # TODO: create this directory for stock sounds?
-SOUND_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'data', 'sounds')
+SOUND_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "..", "data", "sounds"
+)
 
-@tray_registry('cubeviz-sonify-data', label="Sonify Data")
-class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixin,
-                 AddResultsMixin):
+
+@tray_registry("cubeviz-sonify-data", label="Sonify Data")
+class SonifyData(
+    PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixin, AddResultsMixin
+):
     """
     See the :ref:`Sonify Data Plugin Documentation <cubeviz-sonify-data>` for more details.
 
@@ -45,6 +55,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.open_in_tray`
     * :meth:`~jdaviz.core.template_mixin.PluginTemplateMixin.close_in_tray`
     """
+
     template_file = __file__, "sonify_data.vue"
 
     # Removing UI option to vary these for now
@@ -64,14 +75,14 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
     # TODO: can we refresh the list, so sounddevices are up-to-date when dropdown clicked?
     sound_devices_items = List().tag(sync=True)
-    sound_devices_selected = Unicode('').tag(sync=True)
+    sound_devices_selected = Unicode("").tag(sync=True)
 
     add_to_viewer_enabled = Bool(False).tag(sync=True)
 
     # SFX
-    sound_in = Unicode('').tag(sync=True)
-    sound_out = Unicode('').tag(sync=True)
-    sonified_audio_data = Unicode('').tag(sync=True)
+    sound_in = Unicode("").tag(sync=True)
+    sound_out = Unicode("").tag(sync=True)
+    sonified_audio_data = Unicode("").tag(sync=True)
 
     # some addiional attributes for JS
     first_sonification_done = Bool(False).tag(sync=True)
@@ -80,27 +91,29 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._plugin_description = 'Sonify a data cube'
-        self.docs_description = 'Sonify a data cube using the Strauss package.'
+        self._plugin_description = "Sonify a data cube"
+        self.docs_description = "Sonify a data cube using the Strauss package."
         if not self.has_strauss:
-            self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
-                                 'can do this by running pip install strauss in the command'
-                                 ' line and then launching Jdaviz. Currently, this plugin only'
-                                 ' works on devices with valid sound output.')
+            self.disabled_msg = (
+                "To use Sonify Data, install strauss and restart Jdaviz. You "
+                "can do this by running pip install strauss in the command"
+                " line and then launching Jdaviz. Currently, this plugin only"
+                " works on devices with valid sound output."
+            )
 
         else:
             self.sound_device_indexes = None
             self.refresh_device_list()
 
-        self.results_label_default = 'Sonified data'
-        self.add_to_viewer_selected = 'flux-viewer'
+        self.results_label_default = "Sonified data"
+        self.add_to_viewer_selected = "flux-viewer"
 
         # with open(os.path.join(SOUND_DIR, 'in.mp3')) as f:
         #     self.sound_in = f"data:audio/mpeg;base64,{b64encode(f.read).decode('utf-8')}"
 
     @property
     def user_api(self):
-        expose = ['sonify_cube']
+        expose = ["sonify_cube"]
         return PluginUserApi(self, expose)
 
     def sonify_cube(self):
@@ -110,38 +123,58 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         range for sonification.
         """
         if self.disabled_msg:
-            raise ValueError('Unable to sonify cube')
+            raise ValueError("Unable to sonify cube")
 
         # Get index of selected device
         if self.sound_devices_selected:
-            selected_device_index = self.sound_device_indexes[self.sound_devices_selected]
+            selected_device_index = self.sound_device_indexes[
+                self.sound_devices_selected
+            ]
         else:
             selected_device_index = None
-            
+
         # Apply spectral subset bounds
         if self.spectral_subset_selected != self.spectral_subset.default_text:
             display_unit = self.spectrum_viewer.state.x_display_unit
-            min_wavelength = self.spectral_subset.selected_obj.lower.to_value(u.Unit(display_unit))
-            max_wavelength = self.spectral_subset.selected_obj.upper.to_value(u.Unit(display_unit))
-            self.flux_viewer.update_listener_wls((min_wavelength, max_wavelength), display_unit)
+            min_wavelength = self.spectral_subset.selected_obj.lower.to_value(
+                u.Unit(display_unit)
+            )
+            max_wavelength = self.spectral_subset.selected_obj.upper.to_value(
+                u.Unit(display_unit)
+            )
+            self.flux_viewer.update_listener_wls(
+                (min_wavelength, max_wavelength), display_unit
+            )
 
         # Ensure the current spectral region bounds are up-to-date at render time
         self.update_wavelength_range(None)
         # generate the sonified cube
-        sonified_data = self.flux_viewer.get_sonified_cube(self.sample_rate, self.buffer_size,
-                                           selected_device_index, self.assidx, self.ssvidx,
-                                           self.pccut, self.audfrqmin,
-                                           self.audfrqmax, self.eln, self.use_pccut,
-                                           self.results_label)
-        
+        sonified_data = self.flux_viewer.get_sonified_cube(
+            self.sample_rate,
+            self.buffer_size,
+            selected_device_index,
+            self.assidx,
+            self.ssvidx,
+            self.pccut,
+            self.audfrqmin,
+            self.audfrqmax,
+            self.eln,
+            self.use_pccut,
+            self.results_label,
+        )
+
         # In-memory WAV file
         wav_buffer = BytesIO()
-        write_wav(wav_buffer, self.sample_rate, self.flux_viewer.sonified_cube.notification_sounds['on'].astype('int16'))
+        write_wav(
+            wav_buffer,
+            self.sample_rate,
+            self.flux_viewer.sonified_cube.notification_sounds["on"].astype("int16"),
+        )
         wav_buffer.seek(0)
 
-        self.sonified_audio_data = b64encode(wav_buffer.read()).decode('utf-8')
+        self.sonified_audio_data = b64encode(wav_buffer.read()).decode("utf-8")
         self.first_sonification_done = True
-        
+
     @with_spinner()
     def vue_sonify_cube(self, *args):
         self.sonify_cube()
@@ -150,9 +183,9 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         self.stream_active = not self.stream_active
         self.flux_viewer.stream_active = not self.flux_viewer.stream_active
 
-    @observe('spectral_subset_selected')
+    @observe("spectral_subset_selected")
     def update_wavelength_range(self, event):
-        if not hasattr(self, 'spectral_subset'):
+        if not hasattr(self, "spectral_subset"):
             return
         display_unit = self.spectrum_viewer.state.x_display_unit
         # is this spectral selection or the entire spectrum?
@@ -162,14 +195,14 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             wlranges = None
         self.flux_viewer.update_listener_wls(wlranges, display_unit)
 
-    @observe('volume')
+    @observe("volume")
     def update_volume_level(self, event):
-        self.flux_viewer.update_volume_level(event['new'])
+        self.flux_viewer.update_volume_level(event["new"])
 
-    @observe('sound_devices_selected')
+    @observe("sound_devices_selected")
     def update_sound_device(self, event):
-        if event['new'] != event['old']:
-            didx = dict(zip(*self.build_device_lists()))[event['new']]
+        if event["new"] != event["old"]:
+            didx = dict(zip(*self.build_device_lists()))[event["new"]]
             self.flux_viewer.update_sound_device(didx)
 
     def refresh_device_list(self):
@@ -177,9 +210,11 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         self.sound_device_indexes = dict(zip(devices, indexes))
         self.sound_devices_items = devices
         if len(devices) > 0:
-            self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
+            self.sound_devices_selected = dict(zip(indexes, devices))[
+                sd.default.device[1]
+            ]
         else:
-            self.sound_devices_selected = ''
+            self.sound_devices_selected = ""
 
     def vue_refresh_device_list_in_dropdown(self, *args):
         self.refresh_device_list()
@@ -190,7 +225,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         devices = []
         device_indexes = []
         for index, device in enumerate(sd.query_devices()):
-            if device['max_output_channels'] > 0 and device['name'] not in devices:
-                devices.append(device['name'])
+            if device["max_output_channels"] > 0 and device["name"] not in devices:
+                devices.append(device["name"])
                 device_indexes.append(index)
         return devices, device_indexes

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -1,5 +1,6 @@
-from traitlets import Bool, List, Unicode, observe
+from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
+import os
 
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
@@ -24,6 +25,8 @@ except ImportError:
 else:
     _has_strauss = True
 
+# TODO: create this directory for stock sounds?
+SOUND_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'data', 'sounds')
 
 @tray_registry('cubeviz-sonify-data', label="Sonify Data")
 class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMixin,
@@ -54,11 +57,15 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     stream_active = Bool(True).tag(sync=True)
     has_strauss = Bool(_has_strauss).tag(sync=True)
 
-    # TODO: can we referesh the list, so sounddevices are up-to-date when dropdown clicked?
+    # TODO: can we refresh the list, so sounddevices are up-to-date when dropdown clicked?
     sound_devices_items = List().tag(sync=True)
     sound_devices_selected = Unicode('').tag(sync=True)
 
     add_to_viewer_enabled = Bool(False).tag(sync=True)
+
+    # some addiional attributes for JS
+    first_sonification_done = Bool(False).tag(sync=True)
+    thisfile = Unicode(SOUND_DIR).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -110,7 +117,8 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
                                            self.pccut, self.audfrqmin,
                                            self.audfrqmax, self.eln, self.use_pccut,
                                            self.results_label)
-
+        self.first_sonification_done = True
+        
     @with_spinner()
     def vue_sonify_cube(self, *args):
         self.sonify_cube()

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -16,17 +16,18 @@ __all__ = ['SonifyData']
 
 try:
     import strauss
-    import sounddevice as sd
     from scipy.io.wavfile import write as write_wav
+    _has_strauss = True
+except ImportError:
+    _has_strauss = False
+try:
+    import sounddevice as sd
 except ImportError:
     class Empty:
         pass
     sd = Empty()
     sd.default = Empty()
     sd.default.device = [-1, -1]
-    _has_strauss = False
-else:
-    _has_strauss = True
 
 # TODO: create this directory for stock sounds?
 SOUND_DIR = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'data', 'sounds')

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -1,6 +1,7 @@
 from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
 import os
+from io import BytesIO
 
 from base64 import b64encode
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
@@ -14,8 +15,9 @@ from jdaviz.core.user_api import PluginUserApi
 __all__ = ['SonifyData']
 
 try:
-    import strauss  # noqa
+    import strauss
     import sounddevice as sd
+    from scipy.io.wavfile import write as write_wav
 except ImportError:
     class Empty:
         pass
@@ -57,6 +59,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     volume = IntHandleEmpty(100).tag(sync=True)
     stream_active = Bool(True).tag(sync=True)
     has_strauss = Bool(_has_strauss).tag(sync=True)
+    has_outs = Bool((sd.default.device[1] != -1)).tag(sync=True)
 
     # TODO: can we refresh the list, so sounddevices are up-to-date when dropdown clicked?
     sound_devices_items = List().tag(sync=True)
@@ -67,7 +70,8 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
     # SFX
     sound_in = Unicode('').tag(sync=True)
     sound_out = Unicode('').tag(sync=True)
-    
+    sonified_audio_data = Unicode('').tag(sync=True)
+
     # some addiional attributes for JS
     first_sonification_done = Bool(False).tag(sync=True)
     thisfile = Unicode(SOUND_DIR).tag(sync=True)
@@ -77,7 +81,7 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
         self._plugin_description = 'Sonify a data cube'
         self.docs_description = 'Sonify a data cube using the Strauss package.'
-        if not self.has_strauss or sd.default.device[1] < 0:
+        if not self.has_strauss:
             self.disabled_msg = ('To use Sonify Data, install strauss and restart Jdaviz. You '
                                  'can do this by running pip install strauss in the command'
                                  ' line and then launching Jdaviz. Currently, this plugin only'
@@ -108,8 +112,11 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
             raise ValueError('Unable to sonify cube')
 
         # Get index of selected device
-        selected_device_index = self.sound_device_indexes[self.sound_devices_selected]
-
+        if self.sound_devices_selected:
+            selected_device_index = self.sound_device_indexes[self.sound_devices_selected]
+        else:
+            selected_device_index = None
+            
         # Apply spectral subset bounds
         if self.spectral_subset_selected != self.spectral_subset.default_text:
             display_unit = self.spectrum_viewer.state.x_display_unit
@@ -120,11 +127,18 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         # Ensure the current spectral region bounds are up-to-date at render time
         self.update_wavelength_range(None)
         # generate the sonified cube
-        self.flux_viewer.get_sonified_cube(self.sample_rate, self.buffer_size,
+        sonified_data = self.flux_viewer.get_sonified_cube(self.sample_rate, self.buffer_size,
                                            selected_device_index, self.assidx, self.ssvidx,
                                            self.pccut, self.audfrqmin,
                                            self.audfrqmax, self.eln, self.use_pccut,
                                            self.results_label)
+        
+        # In-memory WAV file
+        wav_buffer = BytesIO()
+        write_wav(wav_buffer, self.sample_rate, self.flux_viewer.sonified_cube.notification_sounds['on'].astype('int16'))
+        wav_buffer.seek(0)
+
+        self.sonified_audio_data = b64encode(wav_buffer.read()).decode('utf-8')
         self.first_sonification_done = True
         
     @with_spinner()
@@ -161,7 +175,10 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
         devices, indexes = self.build_device_lists()
         self.sound_device_indexes = dict(zip(devices, indexes))
         self.sound_devices_items = devices
-        self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
+        if len(devices) > 0:
+            self.sound_devices_selected = dict(zip(indexes, devices))[sd.default.device[1]]
+        else:
+            self.sound_devices_selected = ''
 
     def vue_refresh_device_list_in_dropdown(self, *args):
         self.refresh_device_list()

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -2,6 +2,7 @@ from traitlets import Unicode, Bool, List, Unicode, observe
 import astropy.units as u
 import os
 
+from base64 import b64encode
 from jdaviz.core.custom_traitlets import IntHandleEmpty, FloatHandleEmpty
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin, DatasetSelectMixin,
@@ -63,6 +64,10 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
     add_to_viewer_enabled = Bool(False).tag(sync=True)
 
+    # SFX
+    sound_in = Unicode('').tag(sync=True)
+    sound_out = Unicode('').tag(sync=True)
+    
     # some addiional attributes for JS
     first_sonification_done = Bool(False).tag(sync=True)
     thisfile = Unicode(SOUND_DIR).tag(sync=True)
@@ -84,6 +89,9 @@ class SonifyData(PluginTemplateMixin, DatasetSelectMixin, SpectralSubsetSelectMi
 
         self.results_label_default = 'Sonified data'
         self.add_to_viewer_selected = 'flux-viewer'
+
+        # with open(os.path.join(SOUND_DIR, 'in.mp3')) as f:
+        #     self.sound_in = f"data:audio/mpeg;base64,{b64encode(f.read).decode('utf-8')}"
 
     @property
     def user_api(self):

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.py
@@ -19,7 +19,7 @@ from jdaviz.core.user_api import PluginUserApi
 __all__ = ["SonifyData"]
 
 try:
-    import strauss
+    import strauss # noqa
     from scipy.io.wavfile import write as write_wav
     _has_strauss = True
 except ImportError:
@@ -149,7 +149,7 @@ class SonifyData(
         # Ensure the current spectral region bounds are up-to-date at render time
         self.update_wavelength_range(None)
         # generate the sonified cube
-        sonified_data = self.flux_viewer.get_sonified_cube(
+        sonified_data = self.flux_viewer.get_sonified_cube(  # noqa
             self.sample_rate,
             self.buffer_size,
             selected_device_index,

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
@@ -157,3 +157,52 @@
       ></plugin-add-results>
  </j-tray-plugin>
 </template>
+
+<script>
+  // from the Sonify Plugin we can use the WebAudio API for detailed in-browser
+  // control over audio playback.
+  export default {
+    methods: {
+      handleSonifyClick() {
+	// multipurpose function on click - this writes to the browser JS console
+	console.log('Run Sonify Cube...')
+	this.sonify_cube(); // First render sonification...
+      },
+      async setupAudio() {
+	// two birds with one stone - as well as rendering the sonification, the browser
+	// can use the "Sonify Data" button press as the gesture your browser needs in-page
+	// before allowing browser playback...
+	console.log('Take clicking Sonify Data as gesture to initialise Audio Context...');
+	audioContext = await new (window.AudioContext || window.webkitAudioContext)();
+	await this.loadAudio();
+      },
+      async loadAudio() {
+        try {
+	  // Once sonified cube is rendered, for now just play coin sound as an affirmation
+	  // this sound is now being rendered by the browser (not streamed to a sound device by
+	  // python) so should be possible on platforms.
+          const response = await fetch('https://archive.org/download/Castle_2015102/Coin.mp3');
+          const arrayBuffer = await response.arrayBuffer();
+          audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+	  sourceNode = audioContext.createBufferSource();
+          sourceNode.buffer = audioBuffer;
+	  sourceNode.connect(audioContext.destination);
+          sourceNode.start(0);
+        } catch (error) {
+          console.error('Audio load error:', error);
+          throw error;
+        }
+      }
+    },
+    watch: {
+      first_sonification_done(newVal) {
+	// we wait for confirmation the cube has been rendered
+	if (newVal && this.first_sonification_done === true) {
+	  this.setupAudio();
+	  // reset flag so it triggers if we render again...
+	  this.first_sonification_done = false;
+	}
+      }
+    }
+  }
+</script>

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
@@ -141,24 +141,15 @@
         Overall Volume
         <glue-throttled-slider label="Volume" wait="300" max="100" step="1" :value.sync="volume" hide-details class="no-hint" />
     </v-row>
+    
     <j-plugin-section-header>Add Results Options</j-plugin-section-header>
-      <plugin-add-results
-          :label.sync="results_label"
-          :label_default="results_label_default"
-          :label_auto.sync="results_label_auto"
-          :label_invalid_msg="results_label_invalid_msg"
-          :label_overwrite="results_label_overwrite"
-          label_hint="Label for the sonified data"
-          :add_to_viewer_items="add_to_viewer_items"
-          :add_to_viewer_selected.sync="add_to_viewer_selected"
-          :add_to_viewer_enabled="false"
-          action_label="Sonify data"
-          action_tooltip="Create sonified data and add to flux viewer"
-          :action_spinner="spinner"
-          action_api_hint='plg.sonify_cube()'
-          :add_to_viewer_disabled="true"
-          @click:action="sonify_cube"
-      ></plugin-add-results>
+    <v-row>
+    </v-row>
+      <plugin-action-button
+        :spinner="spinner"
+        @click="handleSonifyClick"
+      > Sonify Data
+      </plugin-action-button>
  </j-tray-plugin>
 </template>
 

--- a/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
+++ b/jdaviz/configs/cubeviz/plugins/sonify_data/sonify_data.vue
@@ -14,6 +14,10 @@
       To use Sonify Data, install strauss and restart Jdaviz. You can do this by running pip install strauss
       in the command line and then launching Jdaviz.
     </v-alert>
+    <v-row v-if="has_strauss && !has_outs">
+      <j-docs-link>Sonification on platforms is under construction, and will be silent for now.</j-docs-link>
+    </v-row>
+
     <v-row>
       <j-docs-link>Choose the input cube, spectral subset and any advanced sonification options.</j-docs-link>
     </v-row>
@@ -164,44 +168,54 @@
   export default {
     methods: {
       handleSonifyClick() {
-	// multipurpose function on click - this writes to the browser JS console
-	console.log('Run Sonify Cube...')
-	this.sonify_cube(); // First render sonification...
-      },
-      async setupAudio() {
-	// two birds with one stone - as well as rendering the sonification, the browser
-	// can use the "Sonify Data" button press as the gesture your browser needs in-page
-	// before allowing browser playback...
-	console.log('Take clicking Sonify Data as gesture to initialise Audio Context...');
-	audioContext = await new (window.AudioContext || window.webkitAudioContext)();
-	await this.loadAudio();
+        // multipurpose function on click - this writes to the browser JS console
+        console.log('Run Sonify Cube...')
+        if (!this.audioContext) {
+          console.log('Creating AudioContext...');
+          this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        this.sonify_cube(); // First render sonification...
       },
       async loadAudio() {
         try {
-	  // Once sonified cube is rendered, for now just play coin sound as an affirmation
-	  // this sound is now being rendered by the browser (not streamed to a sound device by
-	  // python) so should be possible on platforms.
-          const response = await fetch('https://archive.org/download/Castle_2015102/Coin.mp3');
-          const arrayBuffer = await response.arrayBuffer();
-          audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-	  sourceNode = audioContext.createBufferSource();
-          sourceNode.buffer = audioBuffer;
-	  sourceNode.connect(audioContext.destination);
-          sourceNode.start(0);
+          // Once sonified cube is rendered, for now just play coin sound as an affirmation
+          // this sound is now being rendered by the browser (not streamed to a sound device by
+          // python) so should be possible on platforms.
+          console.log('New audio data incoming...')
+          const arrayBuffer = this.sonified_audio_data_str.buffer;
+          this.audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+
+          // 1. Create a GainNode to control volume
+          const gainNode = this.audioContext.createGain();
+          gainNode.gain.value = 0.5; 
+          gainNode.connect(this.audioContext.destination);
+          
+          this.sourceNode = this.audioContext.createBufferSource();
+          this.sourceNode.buffer = this.audioBuffer;
+          this.sourceNode.connect(gainNode);
+          this.sourceNode.start(0);
         } catch (error) {
-          console.error('Audio load error:', error);
-          throw error;
+            console.error('Audio load error:', error);
+            throw error;
         }
       }
     },
     watch: {
-      first_sonification_done(newVal) {
-	// we wait for confirmation the cube has been rendered
-	if (newVal && this.first_sonification_done === true) {
-	  this.setupAudio();
-	  // reset flag so it triggers if we render again...
-	  this.first_sonification_done = false;
-	}
+      sonified_audio_data(newVal) {
+        if (newVal) {
+          this.loadAudio();
+        }
+      }
+    },
+    computed: {
+      sonified_audio_data_str() {
+        const binary_string = window.atob(this.sonified_audio_data);
+        const len = binary_string.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+          bytes[i] = binary_string.charCodeAt(i);
+        }
+        return bytes;
       }
     }
   }

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -259,7 +259,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             # and re-clip
             clipped_arr = np.clip(clipped_arr, 0, np.inf)
 
-        self.sonified_cube = CubeListenerData(clipped_arr ** assidx, wlens, duration=0.8,
+        self.sonified_cube = CubeListenerData(clipped_arr ** assidx, wlens, duration=0.2,
                                               samplerate=sample_rate, buffsize=buffer_size,
                                               wl_unit=self.sonification_wl_unit,
                                               audfrqmin=audfrqmin, audfrqmax=audfrqmax,

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -31,7 +31,7 @@ try:
 
     if sd.default.device["output"] < 0:
         _has_sound = False
-except ImportError:
+except (ImportError, OSError):
     _has_sound = False
 if not _has_sound:
 

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -14,30 +14,41 @@ from jdaviz.configs.cubeviz.plugins.mixins import WithSliceIndicator, WithSliceS
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import Spectrum1DViewer
 from jdaviz.core.freezable_state import FreezableBqplotImageViewerState
-from jdaviz.configs.cubeviz.plugins.cube_listener import CubeListenerData, MINVOL, INT_MAX
-from jdaviz.core.sonified_layers import (SonifiedDataLayerArtist,
-                                         SonifiedLayerStateWidget,
-                                         SonifiedLayerState)
+from jdaviz.configs.cubeviz.plugins.cube_listener import (
+    CubeListenerData,
+    MINVOL,
+    INT_MAX,
+)
+from jdaviz.core.sonified_layers import (
+    SonifiedDataLayerArtist,
+    SonifiedLayerStateWidget,
+    SonifiedLayerState,
+)
 
 _has_sound = True
 try:
     import sounddevice as sd
-    if sd.default.device['output'] < 0:
+
+    if sd.default.device["output"] < 0:
         _has_sound = False
 except ImportError:
     _has_sound = False
 if not _has_sound:
+
     class DummySoundDevice:
         class OutputStream:
             def __init__(self, **kwargs):
                 self.closed = False
+
             def stop(self):
                 self.closed = True
-            def start(self):    
+
+            def start(self):
                 self.closed = False
+
     sd = DummySoundDevice()
-    
-__all__ = ['CubevizImageView', 'CubevizProfileView']
+
+__all__ = ["CubevizImageView", "CubevizProfileView"]
 
 
 @viewer_registry("cubeviz-image-viewer", label="Image 2D (Cubeviz)")
@@ -46,14 +57,22 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
     # NOTE: zoom and pan are merged here for space consideration and to avoid
     # overflow to second row when opening the tray
     tools_nested = [
-                    ['jdaviz:homezoom', 'jdaviz:prevzoom'],
-                    ['jdaviz:pixelboxzoommatch', 'jdaviz:boxzoom',
-                     'jdaviz:pixelpanzoommatch', 'jdaviz:panzoom'],
-                    ['bqplot:truecircle', 'bqplot:rectangle', 'bqplot:ellipse',
-                     'bqplot:circannulus'],
-                    ['jdaviz:spectrumperspaxel'],
-                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
-                ]
+        ["jdaviz:homezoom", "jdaviz:prevzoom"],
+        [
+            "jdaviz:pixelboxzoommatch",
+            "jdaviz:boxzoom",
+            "jdaviz:pixelpanzoommatch",
+            "jdaviz:panzoom",
+        ],
+        [
+            "bqplot:truecircle",
+            "bqplot:rectangle",
+            "bqplot:ellipse",
+            "bqplot:circannulus",
+        ],
+        ["jdaviz:spectrumperspaxel"],
+        ["jdaviz:sidebar_plot", "jdaviz:sidebar_export"],
+    ]
 
     default_class = None
     _state_cls = FreezableBqplotImageViewerState
@@ -65,11 +84,11 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         self.state._set_viewer(self)
 
         self._subscribe_to_layers_update()
-        self.state.add_callback('reference_data', self._initial_x_axis)
+        self.state.add_callback("reference_data", self._initial_x_axis)
 
-        self.add_event_callback(self._viewer_mouse_event, events=['mousemove',
-                                                                  'mouseleave',
-                                                                  'mouseenter'])
+        self.add_event_callback(
+            self._viewer_mouse_event, events=["mousemove", "mouseleave", "mouseenter"]
+        )
 
         # Hide axes by default
         self.state.show_axes = False
@@ -81,7 +100,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         self.sonification_wl_unit = None
         self.volume_level = None
 
-        self.data_menu._obj.dataset.add_filter('is_cube_or_image')
+        self.data_menu._obj.dataset.add_filter("is_cube_or_image")
 
         # Dictionary that contains keys with UUIDs for each
         # sonified data layer. The value of each key is another dictionary containing
@@ -90,7 +109,7 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         self.layer_volume = {}
         self.sonified_layers_enabled = []
         self.same_pix = None
-        self._cached_properties = ['combined_sonified_grid']
+        self._cached_properties = ["combined_sonified_grid"]
 
         self._layer_style_widget_cls[SonifiedDataLayerArtist] = SonifiedLayerStateWidget
 
@@ -130,10 +149,11 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         self.figure.axes[1].label_offset = "-50"
 
     def data(self, cls=None):
-        return [layer_state.layer  # .get_object(cls=cls or self.default_class)
-                for layer_state in self.state.layers
-                if hasattr(layer_state, 'layer') and
-                isinstance(layer_state.layer, BaseData)]
+        return [
+            layer_state.layer  # .get_object(cls=cls or self.default_class)
+            for layer_state in self.state.layers
+            if hasattr(layer_state, "layer") and isinstance(layer_state.layer, BaseData)
+        ]
 
     def start_stream(self):
         if self.stream and not self.stream.closed:
@@ -154,22 +174,23 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             # Find layer, add volume check to dictionary and add callback to volume changing and
             # audible changing
             self.layer_volume[layer.layer.label] = layer.volume
-            self.sonified_layers_enabled += ([layer.layer.label] if
-                                             getattr(layer, 'audible', False) else [])
+            self.sonified_layers_enabled += (
+                [layer.layer.label] if getattr(layer, "audible", False) else []
+            )
 
             # TODO: is there a better way to ensure that only unique callbacks are added?
-            layer.remove_callback('volume', self.recalculate_combined_sonified_grid)
-            layer.remove_callback('audible', self.recalculate_combined_sonified_grid)
+            layer.remove_callback("volume", self.recalculate_combined_sonified_grid)
+            layer.remove_callback("audible", self.recalculate_combined_sonified_grid)
 
-            layer.add_callback('volume', self.recalculate_combined_sonified_grid)
-            layer.add_callback('audible', self.recalculate_combined_sonified_grid)
+            layer.add_callback("volume", self.recalculate_combined_sonified_grid)
+            layer.add_callback("audible", self.recalculate_combined_sonified_grid)
 
         # Need to force an update of the layer icons since
         # audible is a state attribute, not a layer artist attribute
         self.jdaviz_app.state.layer_icons.notify_all()
 
-        if 'combined_sonified_grid' in self.__dict__:
-            del self.__dict__['combined_sonified_grid']
+        if "combined_sonified_grid" in self.__dict__:
+            del self.__dict__["combined_sonified_grid"]
         self.combined_sonified_grid
 
     @cached_property
@@ -188,35 +209,43 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             # TODO: apply 1/N or 1/N**0.5 normalisation per layer for N layers?
             for coord, sound_array in v.items():
                 if coord in compiled_coords:
-                    compiled_coords[coord] += ((sound_array * (int(self.layer_volume[k]) / 100)).
-                                               astype(int))
+                    compiled_coords[coord] += (
+                        sound_array * (int(self.layer_volume[k]) / 100)
+                    ).astype(int)
                 else:
-                    compiled_coords[coord] = ((sound_array * (int(self.layer_volume[k]) / 100)).
-                                              astype(int))
+                    compiled_coords[coord] = (
+                        sound_array * (int(self.layer_volume[k]) / 100)
+                    ).astype(int)
         return compiled_coords
 
-    def update_sonified_cube_with_coord(self, coord, vollim='buff'):
+    def update_sonified_cube_with_coord(self, coord, vollim="buff"):
         # Set newsig to the combined sound array at coord
-        if (not self.sonified_layers_enabled or
-                (int(coord[0]), int(coord[1])) not in self.combined_sonified_grid):
+        if (
+            not self.sonified_layers_enabled
+            or (int(coord[0]), int(coord[1])) not in self.combined_sonified_grid
+        ):
             return
 
         # use cached version of combined sonified grid
         compsig = self.combined_sonified_grid[int(coord[0]), int(coord[1])]
 
         # Adjust volume to remove clipping
-        if vollim == 'sig':
+        if vollim == "sig":
             # sigmoidal volume limiting
-            self.sonified_cube.newsig = (erf(compsig/INT_MAX) * INT_MAX).astype('int16')
-        elif vollim == 'clip':
+            self.sonified_cube.newsig = (erf(compsig / INT_MAX) * INT_MAX).astype(
+                "int16"
+            )
+        elif vollim == "clip":
             # hard-clipped volume limiting
-            self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype('int16')
-        elif vollim == 'buff':
+            self.sonified_cube.newsig = np.clip(compsig, -INT_MAX, INT_MAX).astype(
+                "int16"
+            )
+        elif vollim == "buff":
             # renormalise buffer
             sigmax = abs(compsig).max()
             if sigmax > INT_MAX:
-                compsig = ((INT_MAX/abs(compsig).max()) * compsig)
-            self.sonified_cube.newsig = compsig.astype('int16')
+                compsig = (INT_MAX / abs(compsig).max()) * compsig
+            self.sonified_cube.newsig = compsig.astype("int16")
         self.sonified_cube.cbuff = True
 
     def update_listener_wls(self, wranges, wunit):
@@ -228,20 +257,40 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             return
 
         self.stop_stream()
-        self.stream = sd.OutputStream(samplerate=self.sample_rate, blocksize=self.buffer_size,
-                                      device=device_index, channels=1, dtype='int16',
-                                      latency='low', callback=self.sonified_cube.player_callback)
+        self.stream = sd.OutputStream(
+            samplerate=self.sample_rate,
+            blocksize=self.buffer_size,
+            device=device_index,
+            channels=1,
+            dtype="int16",
+            latency="low",
+            callback=self.sonified_cube.player_callback,
+        )
 
     def update_volume_level(self, level):
         if not self.sonified_cube:
             return
         self.volume_level = level
-        self.sonified_cube.atten_level = int(1/np.clip((level/100.)**2, MINVOL, 1))
+        self.sonified_cube.atten_level = int(
+            1 / np.clip((level / 100.0) ** 2, MINVOL, 1)
+        )
 
-    def get_sonified_cube(self, sample_rate, buffer_size, device, assidx, ssvidx,
-                          pccut, audfrqmin, audfrqmax, eln, use_pccut, results_label):
+    def get_sonified_cube(
+        self,
+        sample_rate,
+        buffer_size,
+        device,
+        assidx,
+        ssvidx,
+        pccut,
+        audfrqmin,
+        audfrqmax,
+        eln,
+        use_pccut,
+        results_label,
+    ):
         spectrum = self.active_cube_layer.layer.get_object(statistic=None)
-        wlens = spectrum.wavelength.to('m').value
+        wlens = spectrum.wavelength.to("m").value
         flux = spectrum.flux.value
         self.sample_rate = sample_rate
         self.buffer_size = buffer_size
@@ -250,9 +299,12 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             wdx = np.zeros(wlens.size).astype(bool)
             for r in self.sonification_wl_ranges:
                 # index just the spectral subregion
-                wdx = np.logical_or(wdx,
-                                    np.logical_and(wlens >= r[0].to_value(u.m),
-                                                   wlens <= r[1].to_value(u.m)))
+                wdx = np.logical_or(
+                    wdx,
+                    np.logical_and(
+                        wlens >= r[0].to_value(u.m), wlens <= r[1].to_value(u.m)
+                    ),
+                )
             wlens = wlens[wdx]
             flux = flux[:, :, wdx]
 
@@ -271,18 +323,31 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
             # and re-clip
             clipped_arr = np.clip(clipped_arr, 0, np.inf)
 
-        self.sonified_cube = CubeListenerData(clipped_arr ** assidx, wlens, duration=0.2,
-                                              samplerate=sample_rate, buffsize=buffer_size,
-                                              wl_unit=self.sonification_wl_unit,
-                                              audfrqmin=audfrqmin, audfrqmax=audfrqmax,
-                                              eln=eln, vol=self.volume_level)
+        self.sonified_cube = CubeListenerData(
+            clipped_arr**assidx,
+            wlens,
+            duration=0.2,
+            samplerate=sample_rate,
+            buffsize=buffer_size,
+            wl_unit=self.sonification_wl_unit,
+            audfrqmin=audfrqmin,
+            audfrqmax=audfrqmax,
+            eln=eln,
+            vol=self.volume_level,
+        )
         self.sonified_cube.sonify_cube()
         self.sonified_cube.sigcube = (
-                self.sonified_cube.sigcube * pow(whitelight / whitelight.max(),
-                                                 ssvidx)).astype('int16')
-        self.stream = sd.OutputStream(samplerate=sample_rate, blocksize=buffer_size, device=device,
-                                      channels=1, dtype='int16', latency='low',
-                                      callback=self.sonified_cube.player_callback)
+            self.sonified_cube.sigcube * pow(whitelight / whitelight.max(), ssvidx)
+        ).astype("int16")
+        self.stream = sd.OutputStream(
+            samplerate=sample_rate,
+            blocksize=buffer_size,
+            device=device,
+            channels=1,
+            dtype="int16",
+            latency="low",
+            callback=self.sonified_cube.player_callback,
+        )
         self.sonified_cube.cbuff = True
 
         x_size = self.sonified_cube.sigcube.shape[0]
@@ -290,43 +355,58 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
 
         # Create a new entry for the sonified layer in data_lookup. The value is a dictionary
         # containing (x_size * y_size) keys with values being arrays that represent sounds
-        self.data_lookup[results_label] = {(x, y): self.sonified_cube.sigcube[x, y, :]
-                                           for x in range(0, x_size)
-                                           for y in range(0, y_size)}
+        self.data_lookup[results_label] = {
+            (x, y): self.sonified_cube.sigcube[x, y, :]
+            for x in range(0, x_size)
+            for y in range(0, y_size)
+        }
 
         # Create a 2D array with coordinates starting at (0, 0) and going until (x_size, y_size)
         a = np.arange(1, x_size * y_size + 1).reshape((x_size, y_size))
 
         # Create fake WCS so the sonified layer can be added to a CCDData object and
         # then get added to the image viewer
-        wcs = WCS({'CTYPE1': 'RA---TAN', 'CUNIT1': 'deg', 'CDELT1': -0.0002777777778,
-                   'CRPIX1': 1, 'CRVAL1': 337.5202808,
-                   'CTYPE2': 'DEC--TAN', 'CUNIT2': 'deg', 'CDELT2': 0.0002777777778,
-                   'CRPIX2': 1, 'CRVAL2': -20.833333059999998})
+        wcs = WCS(
+            {
+                "CTYPE1": "RA---TAN",
+                "CUNIT1": "deg",
+                "CDELT1": -0.0002777777778,
+                "CRPIX1": 1,
+                "CRVAL1": 337.5202808,
+                "CTYPE2": "DEC--TAN",
+                "CUNIT2": "deg",
+                "CDELT2": 0.0002777777778,
+                "CRPIX2": 1,
+                "CRVAL2": -20.833333059999998,
+            }
+        )
 
         # Create add data with name results_label to data collection and then add it to the
         # flux viewer
-        sonified_cube = CCDData(a * u.Unit(''), wcs=wcs)
+        sonified_cube = CCDData(a * u.Unit(""), wcs=wcs)
         self.jdaviz_app.data_collection[results_label] = sonified_cube
-        self.jdaviz_app.data_collection[results_label].meta['Sonified'] = True
+        self.jdaviz_app.data_collection[results_label].meta["Sonified"] = True
 
-        self.jdaviz_app.add_data_to_viewer('flux-viewer', results_label)
+        self.jdaviz_app.add_data_to_viewer("flux-viewer", results_label)
 
         # Clear cache and recompute
         self.recalculate_combined_sonified_grid()
 
         return self.sonified_cube.sigcube
-        
+
     def _viewer_mouse_event(self, data):
-        if data['event'] in ('mouseleave', 'mouseenter') or not self.sonified_layers_enabled:
+        if (
+            data["event"] in ("mouseleave", "mouseenter")
+            or not self.sonified_layers_enabled
+        ):
             self.stop_stream()
             return
         if len(self.jdaviz_app.data_collection) < 1:
             return
 
         # Extract data coordinates - these are pixels in the reference image
-        x = np.floor(data['domain']['x'])
-        y = np.floor(data['domain']['y'])
+        x = np.floor(data["domain"]["x"])
+        y = np.floor(data["domain"]["y"])
 
         if x is None or y is None or x < 0 or y < 0:  # Out of bounds
             return
@@ -336,14 +416,17 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         elif (x, y) == self.same_pix:
             return
 
-        if (not self.sonified_cube or not hasattr(self.sonified_cube, 'newsig') or
-                not hasattr(self.sonified_cube, 'sigcube')):
+        if (
+            not self.sonified_cube
+            or not hasattr(self.sonified_cube, "newsig")
+            or not hasattr(self.sonified_cube, "sigcube")
+        ):
             return
         self.start_stream()
         self.update_sonified_cube_with_coord((x, y))
 
     def get_data_layer_artist(self, layer=None, layer_state=None):
-        if 'Sonified' in layer.meta:
+        if "Sonified" in layer.meta:
             cls = SonifiedDataLayerArtist
             return self.get_layer_artist(cls, layer=layer)
         else:
@@ -354,16 +437,16 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
 class CubevizProfileView(Spectrum1DViewer, WithSliceIndicator):
     # categories: zoom resets, zoom, pan, subset, select tools, shortcuts
     tools_nested = [
-                    ['jdaviz:homezoom', 'jdaviz:prevzoom'],
-                    ['jdaviz:boxzoom', 'jdaviz:xrangezoom', 'jdaviz:yrangezoom'],
-                    ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
-                    ['bqplot:xrange'],
-                    ['jdaviz:selectslice', 'jdaviz:selectline'],
-                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
-                ]
+        ["jdaviz:homezoom", "jdaviz:prevzoom"],
+        ["jdaviz:boxzoom", "jdaviz:xrangezoom", "jdaviz:yrangezoom"],
+        ["jdaviz:panzoom", "jdaviz:panzoom_x", "jdaviz:panzoom_y"],
+        ["bqplot:xrange"],
+        ["jdaviz:selectslice", "jdaviz:selectline"],
+        ["jdaviz:sidebar_plot", "jdaviz:sidebar_export"],
+    ]
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default_tool_priority', ['jdaviz:selectslice'])
+        kwargs.setdefault("default_tool_priority", ["jdaviz:selectslice"])
         super().__init__(*args, **kwargs)
 
     @property

--- a/jdaviz/configs/cubeviz/plugins/viewers.py
+++ b/jdaviz/configs/cubeviz/plugins/viewers.py
@@ -19,12 +19,24 @@ from jdaviz.core.sonified_layers import (SonifiedDataLayerArtist,
                                          SonifiedLayerStateWidget,
                                          SonifiedLayerState)
 
-
+_has_sound = True
 try:
     import sounddevice as sd
+    if sd.default.device['output'] < 0:
+        _has_sound = False
 except ImportError:
-    pass
-
+    _has_sound = False
+if not _has_sound:
+    class DummySoundDevice:
+        class OutputStream:
+            def __init__(self, **kwargs):
+                self.closed = False
+            def stop(self):
+                self.closed = True
+            def start(self):    
+                self.closed = False
+    sd = DummySoundDevice()
+    
 __all__ = ['CubevizImageView', 'CubevizProfileView']
 
 
@@ -303,6 +315,8 @@ class CubevizImageView(JdavizViewerMixin, WithSliceSelection, BqplotImageView):
         # Clear cache and recompute
         self.recalculate_combined_sonified_grid()
 
+        return self.sonified_cube.sigcube
+        
     def _viewer_mouse_event(self, data):
         if data['event'] in ('mouseleave', 'mouseenter') or not self.sonified_layers_enabled:
             self.stop_stream()


### PR DESCRIPTION
setup that should work locally and on platforms while trying to transition all audio to in-browser. This should catch systems without `PortAudio` or with no output device (typically remote servers) and use a dummy audio device for now, while working as before locally. 

This also includes an in-browser affirmation that the sonification sound generation is complete, that plays thtrough JS in-browser, as a proof-of-concept. This uses a JS wrapper function.

Something I'm yet to understand is the `<plugin-add-results>` button - I haven't got the JS function to work for this yet, so I revert to the `<plugin-action-button>` for now

If you could try this on a platform context that would be great - I've tried to simulate this myself but don't know if I'm replicating all the conditions correctly.